### PR TITLE
Fix mysqladmin path in restore script

### DIFF
--- a/overwrite/synology-gitlab/scripts/restore
+++ b/overwrite/synology-gitlab/scripts/restore
@@ -44,7 +44,7 @@ while [ $# -ge 1 ]; do
             maria_db_root_password="$2"; shift 2
             if ! [ -z "$maria_db_root_password" ]; then
                 MARIADB_PASS="${maria_db_root_password:+-p$maria_db_root_password}"
-                if [ "$(mysqladmin ping "$MARIADB_PASS")" != "mysqld is alive" ]; then
+                if [ "$($MYSQL10_BIN_DIR/mysqladmin ping "$MARIADB_PASS")" != "mysqld is alive" ]; then
                     exit 1
                 fi
             fi


### PR DESCRIPTION
mysqladmin command in restore script isn't prefixed by $MYSQL10_BIN_DIR, causing the script fails to run with following error.

`./restore: line 47: mysqladmin: command not found`

I fixed this issue by prefixing mysqladmin with $MYSQL10_BIN_DIR, just as in backup script.
